### PR TITLE
[WIP] Adding errcheck plugin

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -1,67 +1,12 @@
 name    = Code-TidyAll-Plugin-Go
 author  = Gregory Oschwald <goschwald@maxmind.com>
 license = Perl_5
-copyright_holder = MaxMind, Inc.
 
 version = 0.02
+main_module = lib/Code/TidyAll/Plugin/Go.pm
 
-[NextRelease]
-format = %-8v %{yyyy-MM-dd}d
-
-[Authority]
-authority = cpan:MAXMIND
-do_munging = 0
-
-[@Filter]
--bundle = @Basic
--remove = GatherDir
--remove = License
--remove = Readme
--remove = UploadToCPAN
-
-[UploadToCPAN]
-pause_cfg_file = .pause-maxmind
-
-[GatherDir]
-exclude_filename = README.md
-
-[ContributorsFromGit]
-[CopyReadmeFromBuild]
-[InstallGuide]
-[MetaJSON]
-
-[ReadmeAnyFromPod / ReadmeMarkdownInBuild]
-filename = README.md
-
-[ReadmeAnyFromPod / ReadmeMarkdownInRoot]
-filename = README.md
-phase = release
-
-[GitHub::Meta]
-
-[SurgicalPodWeaver]
-
-[PkgVersion]
-
-[EOLTests]
-[PodCoverageTests]
-[PodSyntaxTests]
-[Test::CPAN::Changes]
-[Test::Compile]
-[Test::NoTabs]
-[Test::Portability]
-[Test::Pod::LinkCheck]
-[Test::Pod::No404s]
-[Test::PodSpelling]
+[@MAXMIND]
+dist = Code-TidyAll-Plugin-Go
 stopwords = GitHub
 stopwords = distro
 stopwords = gofmt
-[Test::ReportPrereqs]
-
-[AutoPrereqs]
-
-[CheckPrereqsIndexed]
-
-[@Git]
-allow_dirty = Changes
-allow_dirty = README.md

--- a/lib/Code/TidyAll/Plugin/Go.pm
+++ b/lib/Code/TidyAll/Plugin/Go.pm
@@ -1,12 +1,16 @@
 package Code::TidyAll::Plugin::Go;
 
-# ABSTRACT: Provides gofmt and go vet plugins for Code::TidyAll
+# ABSTRACT: Provides errcheck, gofmt and go vet plugins for Code::TidyAll
 
 __END__
 
 =head1 SYNOPSIS
 
 In your F<.tidyallrc> file:
+
+    [Go::Errcheck]
+    select = ./main.go
+    argv = -blank $ROOT/testdata
 
     [Go::Fmt]
     select = **/*.go
@@ -16,10 +20,12 @@ In your F<.tidyallrc> file:
 
 =head1 DESCRIPTION
 
-This distro ships with two Go-related plugins for L<Code::TidyAll>. The
-C<Go::Fmt> plugin formats your code with C<gofmt>. The C<Go::Vet> plugin runs
-C<go vet> against your code and dies if that command finds anything to
-complain about.
+This distro ships with three Go-related plugins for L<Code::TidyAll>: one
+formatter and two validators. The C<Go::Fmt> plugin formats your code with
+C<gofmt>. The C<Go::Errcheck> plugin runs
+L<errcheck|https://github.com/kisielk/errcheck> against your code and the
+C<Go::Vet> plugin runs C<go vet> against your code.  Both of these validator
+plugins will die if their respective commands find anything to complain about.
 
 =head1 SUPPORT
 

--- a/lib/Code/TidyAll/Plugin/Go/Errcheck.pm
+++ b/lib/Code/TidyAll/Plugin/Go/Errcheck.pm
@@ -1,0 +1,31 @@
+package Code::TidyAll::Plugin::Go::Errcheck;
+
+use strict;
+use warnings;
+use feature qw( say );
+
+use IPC::Run3 qw( run3 );
+use Moo;
+
+extends 'Code::TidyAll::Plugin';
+
+sub _build_cmd { 'errcheck' }
+
+sub validate_file {
+    my ( $self, $file ) = @_;
+
+    my $argv = $self->argv;
+    $argv =~ s{$ENV{GOPATH}/src/}{};
+
+    my $cmd = join q{ }, $self->cmd, $argv;
+
+    my $output;
+    run3( $cmd, \undef, \$output, \$output );
+    if ( $? > 0 ) {
+        $output ||= 'problem running ' . $self->cmd;
+        die "$output\n";
+    }
+
+}
+
+1;


### PR DESCRIPTION
This is just a temporary hack.  The first problem is that TidyAll wants to
scan file names and errcheck wants to check packages.  So, the best
TidyAll can give you is a list of files in your repo.  You could argue
that it's possible to work your way back from these files and figure out
what the package is, but TidyAll opens the files into a temporary
directory, so you don't know much about the folder structure of the
place where the file actually lives.

I think TidyAll may need a validate_directory method. Or maybe it needs
the ability to set the command via argv and not require any matching
files to be found in order.  Or, maybe it needs the functionality to
pass args to the plugin, but not to the CLI itself.
