### PR TITLE
Use `go tool vet`

### DIFF
--- a/lib/Code/TidyAll/Plugin/Go/Vet.pm
+++ b/lib/Code/TidyAll/Plugin/Go/Vet.pm
@@ -8,7 +8,7 @@ use Moo;
 
 extends 'Code::TidyAll::Plugin';
 
-sub _build_cmd { 'go vet' }
+sub _build_cmd { 'go tool vet' }
 
 sub validate_file {
     my ( $self, $file ) = @_;


### PR DESCRIPTION
As of 1.10, `go vet` no longer works correctly on individual files. As
such, we use `go tool vet` instead. See
https://github.com/golang/go/issues/23916 for more information.